### PR TITLE
Please expose item tapped function to objective C

### DIFF
--- a/MiniTabBar/Classes/MiniTabBar.swift
+++ b/MiniTabBar/Classes/MiniTabBar.swift
@@ -183,7 +183,7 @@ import UIKit
         }
     }
     
-    func itemTapped(_ gesture: UITapGestureRecognizer) {
+    @objc public func itemTapped(_ gesture: UITapGestureRecognizer) {
         let itemView = gesture.view as! MiniTabBarItemView
         let selectedIndex = self.itemViews.index(of: itemView)!
         self.selectItem(selectedIndex)


### PR DESCRIPTION
Getting this error
/Users/shiv19/Work/AnyGo/apps/userApp/platforms/ios/Pods/MiniTabBar/MiniTabBar/Classes/MiniTabBar.swift:161:88: error: argument of '#selector' refers to instance method 'itemTapped' that is not exposed to Objective-C
            itemView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(MiniTabBar.itemTapped(_:))))
           ^                    ~~~~~~~~~~~~~~
/Users/shiv19/Work/AnyGo/apps/userApp/platforms/ios/Pods/MiniTabBar/MiniTabBar/Classes/MiniTabBar.swift:186:10: note: add '@objc' to expose this instance method to Objective-C
    func itemTapped(_ gesture: UITapGestureRecognizer) {