### PR TITLE
trigger tabSelected event when same tab is selected

### DIFF
--- a/MiniTabBar/Classes/MiniTabBar.swift
+++ b/MiniTabBar/Classes/MiniTabBar.swift
@@ -195,14 +195,13 @@ import UIKit
         if !self.itemViews[selectedIndex].item.selectable {
             return
         }
-        if (selectedIndex == self.currentSelectedIndex) {
-            return
-        }
-        for (index, v) in self.itemViews.enumerated() {
-            if (self.currentSelectedIndex != nil) {
-                    v.deSelected((index == self.currentSelectedIndex), animated: animated);
+        if (selectedIndex != self.currentSelectedIndex) {
+            for (index, v) in self.itemViews.enumerated() {
+                if (self.currentSelectedIndex != nil) {
+                        v.deSelected((index == self.currentSelectedIndex), animated: animated);
+                }
+                v.setSelected((index == selectedIndex), animated: animated)
             }
-            v.setSelected((index == selectedIndex), animated: animated)
         }
         self.currentSelectedIndex = selectedIndex
         self.delegate?.tabSelected(selectedIndex)


### PR DESCRIPTION
Tapping on selected tab triggers `tabSelected`

Fixes https://github.com/rhanb/nativescript-bottombar/issues/73 for ios